### PR TITLE
esp32/8266: WLAN(): add support for set/get wifi power saving mode.

### DIFF
--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -493,6 +493,10 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
                         esp_exceptions(esp_wifi_set_protocol(self->if_id, mp_obj_get_int(kwargs->table[i].value)));
                         break;
                     }
+                    case MP_QSTR_pm: {
+                        esp_exceptions(esp_wifi_set_ps(mp_obj_get_int(kwargs->table[i].value)));
+                        break;
+                    }
                     default:
                         goto unknown;
                 }
@@ -587,6 +591,12 @@ STATIC mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
             val = MP_OBJ_NEW_SMALL_INT(protocol_bitmap);
             break;
         }
+        case MP_QSTR_pm: {
+            wifi_ps_type_t ps_type;
+            esp_exceptions(esp_wifi_get_ps(&ps_type));
+            val = MP_OBJ_NEW_SMALL_INT(ps_type);
+            break;
+        }
         default:
             goto unknown;
     }
@@ -612,6 +622,11 @@ STATIC const mp_rom_map_elem_t wlan_if_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_isconnected), MP_ROM_PTR(&network_wlan_isconnected_obj) },
     { MP_ROM_QSTR(MP_QSTR_config), MP_ROM_PTR(&network_wlan_config_obj) },
     { MP_ROM_QSTR(MP_QSTR_ifconfig), MP_ROM_PTR(&esp_ifconfig_obj) },
+
+    // Constants
+    { MP_ROM_QSTR(MP_QSTR_PM_NONE), MP_ROM_INT(WIFI_PS_NONE) },
+    { MP_ROM_QSTR(MP_QSTR_PM_MIN_MODEM), MP_ROM_INT(WIFI_PS_MIN_MODEM) },
+    { MP_ROM_QSTR(MP_QSTR_PM_MAX_MODEM), MP_ROM_INT(WIFI_PS_MAX_MODEM) },
 };
 STATIC MP_DEFINE_CONST_DICT(wlan_if_locals_dict, wlan_if_locals_dict_table);
 

--- a/ports/esp8266/modnetwork.c
+++ b/ports/esp8266/modnetwork.c
@@ -410,6 +410,10 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                         wifi_set_phy_mode(mp_obj_get_int(kwargs->table[i].value));
                         break;
                     }
+                    case MP_QSTR_pm: {
+                        wifi_set_sleep_type(mp_obj_get_int(kwargs->table[i].value));
+                        break;
+                    }
                     default:
                         goto unknown;
                 }
@@ -481,6 +485,10 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
             val = mp_obj_new_int(wifi_get_phy_mode());
             break;
         }
+        case MP_QSTR_pm: {
+            val = MP_OBJ_NEW_SMALL_INT(wifi_get_sleep_type());
+            break;
+        }
         default:
             goto unknown;
     }
@@ -506,6 +514,12 @@ STATIC const mp_rom_map_elem_t wlan_if_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_isconnected), MP_ROM_PTR(&esp_isconnected_obj) },
     { MP_ROM_QSTR(MP_QSTR_config), MP_ROM_PTR(&esp_config_obj) },
     { MP_ROM_QSTR(MP_QSTR_ifconfig), MP_ROM_PTR(&esp_ifconfig_obj) },
+
+    // Constants
+    { MP_ROM_QSTR(MP_QSTR_PM_NONE), MP_ROM_INT(NONE_SLEEP_T) },
+    { MP_ROM_QSTR(MP_QSTR_PM_MIN_MODEM), MP_ROM_INT(MODEM_SLEEP_T) },
+    { MP_ROM_QSTR(MP_QSTR_PM_MAX_MODEM), MP_ROM_INT(MODEM_SLEEP_T) },
+    { MP_ROM_QSTR(MP_QSTR_PM_LIGHT_SLEEP), MP_ROM_INT(LIGHT_SLEEP_T) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(wlan_if_locals_dict, wlan_if_locals_dict_table);


### PR DESCRIPTION
For esp32 and esp8266: adds:
- 'pm' option to WLAN.config() to set/get the wifi power saving mode; and
- PM_NONE, PM_MIN_MODEM, PM_MAX_MODEM and PM_LIGHT_SLEEP (eps8266 only) constants to the WLAN class.